### PR TITLE
set up endpoint for translator signup

### DIFF
--- a/auth/jwt.js
+++ b/auth/jwt.js
@@ -1,0 +1,13 @@
+const jwt = require("jsonwebtoken");
+
+const { jwtSecret } = require("../config/secrets");
+
+function toJWT(data) {
+  return jwt.sign(data, jwtSecret, { expiresIn: "2h" });
+}
+
+function toData(token) {
+  return jwt.verify(token, jwtSecret);
+}
+
+module.exports = { toJWT, toData };

--- a/auth/middleware.js
+++ b/auth/middleware.js
@@ -1,0 +1,48 @@
+const User = require("../models").user;
+const { toData } = require("./jwt");
+
+async function auth(req, res, next) {
+  const auth =
+    req.headers.authorization && req.headers.authorization.split(" ");
+
+  if (!auth || !auth[0] === "Bearer" || !auth[1]) {
+    res.status(401).send({
+      message:
+        "This endpoint requires an Authorization header with a valid token",
+    });
+  }
+
+  try {
+    const data = toData(auth[1]);
+    const user = await User.findByPk(data.userId);
+    if (!user) {
+      return res.status(404).send({ message: "User does not exist" });
+    }
+
+    // add user object to request
+    req.user = user;
+    // next handler
+    return next();
+  } catch (error) {
+    console.log("ERROR IN AUTH MIDDLEWARE", error);
+
+    switch (error.name) {
+      case "TokenExpiredError":
+        return res
+          .status(401)
+          .send({ error: error.name, message: error.message });
+
+      case "JsonWebTokenError":
+        return res
+          .status(400)
+          .send({ error: error.name, message: error.message });
+
+      default:
+        return res.status(400).send({
+          message: "Something went wrong, sorry",
+        });
+    }
+  }
+}
+
+module.exports = auth;

--- a/config/secrets.js
+++ b/config/secrets.js
@@ -1,0 +1,3 @@
+module.exports = {
+  jwtSecret: process.env.JWT_SECRET || "e9rp^&^*&@9sejg)DSUA)jpfds8394jdsfn,m",
+};

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const corsMiddleWare = require("cors");
 const { PORT } = require("./config/constants");
 const userRouter = require("./routers/user");
 const authRouter = require("./routers/auth");
+const translationRouter = require("./routers/translation");
 
 const app = express();
 
@@ -14,6 +15,7 @@ app.use(corsMiddleWare());
 
 app.use("/", userRouter);
 app.use("/", authRouter);
+app.use("/", translationRouter);
 
 app.listen(PORT, () => {
   console.log(`Listening on port: ${PORT}`);

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ const express = require("express");
 const corsMiddleWare = require("cors");
 const { PORT } = require("./config/constants");
 const userRouter = require("./routers/user");
+const authRouter = require("./routers/auth");
 
 const app = express();
 
@@ -12,6 +13,7 @@ app.use(bodyParserMiddleWare);
 app.use(corsMiddleWare());
 
 app.use("/", userRouter);
+app.use("/", authRouter);
 
 app.listen(PORT, () => {
   console.log(`Listening on port: ${PORT}`);

--- a/routers/auth.js
+++ b/routers/auth.js
@@ -1,76 +1,121 @@
-// const bcrypt = require("bcrypt");
-// const { Router } = require("express");
-// const { toJWT } = require("../auth/jwt");
-// const authMiddleware = require("../auth/middleware");
-// const User = require("../models/").user;
-// const { SALT_ROUNDS } = require("../config/constants");
+const bcrypt = require("bcrypt");
+const { Router } = require("express");
+const { toJWT } = require("../auth/jwt");
+const authMiddleware = require("../auth/middleware");
+const User = require("../models/").user;
+const Profile = require("../models").profile;
+const { SALT_ROUNDS } = require("../config/constants");
 
-// const router = new Router();
+const router = new Router();
 
-// router.post("/login", async (req, res, next) => {
-//   try {
-//     const { email, password } = req.body;
+router.post("/login", async (req, res, next) => {
+  try {
+    const { emailAddress, password } = req.body;
 
-//     if (!email || !password) {
-//       return res
-//         .status(400)
-//         .send({ message: "Please provide both email and password" });
-//     }
+    if (!emailAddress || !password) {
+      return res
+        .status(400)
+        .send({ message: "Please provide both email and password" });
+    }
 
-//     const user = await User.findOne({ where: { email } });
+    const user = await User.findOne({ where: { emailAddress } });
 
-//     if (!user || !bcrypt.compareSync(password, user.password)) {
-//       return res.status(400).send({
-//         message: "User with that email not found or password incorrect",
-//       });
-//     }
+    if (!user || !bcrypt.compareSync(password, user.password)) {
+      return res.status(400).send({
+        message: "User with that email not found or password incorrect",
+      });
+    }
 
-//     delete user.dataValues["password"]; // don't send back the password hash
-//     const token = toJWT({ userId: user.id });
-//     return res.status(200).send({ token, ...user.dataValues });
-//   } catch (error) {
-//     console.log(error);
-//     return res.status(400).send({ message: "Something went wrong, sorry" });
-//   }
-// });
+    delete user.dataValues["password"]; // don't send back the password hash
+    const token = toJWT({ userId: user.id });
+    return res.status(200).send({ token, ...user.dataValues });
+  } catch (error) {
+    console.log(error);
+    return res.status(400).send({ message: "Something went wrong, sorry" });
+  }
+});
 
-// router.post("/signup", async (req, res) => {
-//   const { email, password, name, isArtist } = req.body;
-//   if (!email || !password || !name) {
-//     return res.status(400).send("Please provide an email, password and a name");
-//   }
+router.post("/signup", async (req, res) => {
+  const { email, password, name } = req.body;
+  if (!email || !password || !name) {
+    return res.status(400).send("Please provide an email, password and a name");
+  }
 
-//   try {
-//     const newUser = await User.create({
-//       email,
-//       password: bcrypt.hashSync(password, SALT_ROUNDS),
-//       name,
-//       isArtist,
-//     });
+  try {
+    const newUser = await User.create({
+      email,
+      password: bcrypt.hashSync(password, SALT_ROUNDS),
+      name,
+      isTranslator: false,
+    });
 
-//     delete newUser.dataValues["password"]; // don't send back the password hash
+    delete newUser.dataValues["password"]; // don't send back the password hash
 
-//     const token = toJWT({ userId: newUser.id });
+    const token = toJWT({ userId: newUser.id });
 
-//     res.status(201).json({ token, ...newUser.dataValues });
-//   } catch (error) {
-//     if (error.name === "SequelizeUniqueConstraintError") {
-//       return res
-//         .status(400)
-//         .send({ message: "There is an existing account with this email" });
-//     }
+    res.status(201).json({ token, ...newUser.dataValues });
+  } catch (error) {
+    if (error.name === "SequelizeUniqueConstraintError") {
+      return res
+        .status(400)
+        .send({ message: "There is an existing account with this email" });
+    }
 
-//     return res.status(400).send({ message: "Something went wrong, sorry" });
-//   }
-// });
+    return res.status(400).send({ message: "Something went wrong, sorry" });
+  }
+});
 
-// // The /me endpoint can be used to:
-// // - get the users email & name using only their token
-// // - checking if a token is (still) valid
-// router.get("/me", authMiddleware, async (req, res) => {
-//   // don't send back the password hash
-//   delete req.user.dataValues["password"];
-//   res.status(200).send({ ...req.user.dataValues });
-// });
+router.post("/signup/translator", async (req, res) => {
+  const {
+    fullName,
+    emailAddress,
+    password,
+    imageUrl,
+    experience,
+    writingStyle,
+  } = req.body;
+  if (!fullName || !emailAddress || !password || !experience || !writingStyle) {
+    return res.status(400).send("Please fill in all the fields correctly");
+  }
 
-// module.exports = router;
+  try {
+    const newUser = await User.create({
+      fullName,
+      emailAddress,
+      password: bcrypt.hashSync(password, SALT_ROUNDS),
+      imageUrl,
+      isTranslator: true,
+    });
+
+    await Profile.create({
+      experience,
+      writingStyle,
+      userId: newUser.id,
+    });
+
+    delete newUser.dataValues["password"]; // don't send back the password hash
+
+    const token = toJWT({ userId: newUser.id });
+
+    res.status(201).json({ token, ...newUser.dataValues });
+  } catch (error) {
+    if (error.name === "SequelizeUniqueConstraintError") {
+      return res
+        .status(400)
+        .send({ message: "There is an existing account with this email" });
+    }
+
+    return res.status(400).send({ message: "Something went wrong, sorry" });
+  }
+});
+
+// The /me endpoint can be used to:
+// - get the users email & name using only their token
+// - checking if a token is (still) valid
+router.get("/me", authMiddleware, async (req, res) => {
+  // don't send back the password hash
+  delete req.user.dataValues["password"];
+  res.status(200).send({ ...req.user.dataValues });
+});
+
+module.exports = router;

--- a/routers/auth.js
+++ b/routers/auth.js
@@ -110,7 +110,7 @@ router.post("/signup/translator", async (req, res) => {
 });
 
 // The /me endpoint can be used to:
-// - get the users email & name using only their token
+// - get the user information using only their token
 // - checking if a token is (still) valid
 router.get("/me", authMiddleware, async (req, res) => {
   // don't send back the password hash

--- a/routers/translation.js
+++ b/routers/translation.js
@@ -1,0 +1,38 @@
+const { Router } = require("express");
+const Language = require("../models").language;
+const Profile = require("../models").profile;
+const User = require("../models").user;
+
+const router = new Router();
+
+//get all languages in database (for selection in order process)
+router.get("/languages", async (req, res) => {
+  const limit = req.query.limit || 30;
+  const offset = req.query.offset || 0;
+  const languages = await Language.findAndCountAll({
+    limit,
+    offset,
+    attributes: ["originalLanguage", "nativeLanguage"],
+  });
+  res.status(200).send({ message: "success", languages });
+});
+
+//get the profiles of all translators
+router.get("/translators", async (req, res) => {
+  const limit = req.query.limit || 30;
+  const offset = req.query.offset || 0;
+  const profiles = await Profile.findAndCountAll({
+    limit,
+    offset,
+    include: [
+      { model: User, attributes: ["fullName", "imageUrl"] },
+      {
+        model: Language,
+        attributes: ["originalLanguage", "nativeLanguage"],
+      },
+    ],
+  });
+  res.status(200).send({ message: "success", profiles });
+});
+
+module.exports = router;

--- a/routers/user.js
+++ b/routers/user.js
@@ -1,55 +1,11 @@
 const { Router } = require("express");
+const auth = require("../auth/middleware");
 const Language = require("../models").language;
-const Translator = require("../models").profile;
+const Profile = require("../models").profile;
 const User = require("../models").user;
 const Job = require("../models").job;
 
 const router = new Router();
-
-//get all languages in database (for selection in order process)
-router.get("/languages", async (req, res) => {
-  const limit = req.query.limit || 30;
-  const offset = req.query.offset || 0;
-  const languages = await Language.findAndCountAll({
-    limit,
-    offset,
-    attributes: ["originalLanguage", "nativeLanguage"],
-  });
-  res.status(200).send({ message: "success", languages });
-});
-
-//get the profiles of all translators
-router.get("/translators", async (req, res) => {
-  const limit = req.query.limit || 30;
-  const offset = req.query.offset || 0;
-  const profiles = await Translator.findAndCountAll({
-    limit,
-    offset,
-    include: [
-      { model: User, attributes: ["fullName", "imageUrl"] },
-      {
-        model: Language,
-        attributes: ["originalLanguage", "nativeLanguage"],
-      },
-    ],
-  });
-  res.status(200).send({ message: "success", profiles });
-});
-
-//get all jobs based on profile Id
-router.get("/user/:id/jobs", async (req, res) => {
-  const { id } = req.params;
-
-  console.log(id);
-  if (isNaN(parseInt(id))) {
-    return res.status(400).send({ message: "Profile id is not a number" });
-  }
-  const jobs = await Job.findAll({
-    where: { profileId: id },
-  });
-
-  res.status(200).send({ message: "ok", jobs });
-});
 
 //create a new job in the database
 router.post("/user/order", async (req, res) => {
@@ -66,10 +22,7 @@ router.post("/user/order", async (req, res) => {
   } = req.body;
 
   try {
-    const profile = await Translator.findByPk(profileId);
-
-    console.log("WAHATS ID>", profileId);
-    console.log("WHATS PROFILE?", profile);
+    const profile = await Profile.findByPk(profileId);
 
     if (profile === null) {
       return res
@@ -109,6 +62,33 @@ router.post("/user/order", async (req, res) => {
     console.log(error);
     return res.status(400).send({ message: "ERROR something went wrong" });
   }
+});
+
+//get all jobs based on profile Id
+router.get("/user/:id/jobs", auth, async (req, res) => {
+  const { id } = req.params;
+  const profile = await Profile.findByPk(id);
+  console.log("whats profile?", profile);
+
+  if (profile === null) {
+    return res.status(404).send({ message: "This profile does not exist" });
+  }
+
+  if (!profile.userId === id) {
+    return res
+      .status(403)
+      .send({ message: "You are not authorized to view this." });
+  }
+
+  if (isNaN(parseInt(id))) {
+    return res.status(400).send({ message: "Profile id is not a number" });
+  }
+
+  const jobs = await Job.findAll({
+    where: { profileId: id },
+  });
+
+  res.status(200).send({ message: "ok", jobs });
 });
 
 module.exports = router;


### PR DESCRIPTION
#### What's in this pull request 

❇️  auth directory, containing:
* JWT signup and verification.
* authentication middleware.

❇️  Sign-up endpoints for both customers and translators.
❇️  Login endpoint that retrieves user information.
❇️  A /me endpoint that:
*  get the user information using only their token
*  checks if a token is (still) valid

#### Why this pull request 

As a user of the site, I want to be able to log in. Translators would want access to their dashboard and this should become available when logged in. This should not be the case for customers. 
To prevent tedious logging in after every break away from the site, a jwt token check runs every time the site is refreshed. 
